### PR TITLE
Fix move maker test

### DIFF
--- a/test/com/barrybecker4/game/twoplayer/common/search/strategy/UctNodeTest.java
+++ b/test/com/barrybecker4/game/twoplayer/common/search/strategy/UctNodeTest.java
@@ -1,11 +1,14 @@
 /* Copyright by Barry G. Becker, 2000-2011. Licensed under MIT License: http://www.opensource.org/licenses/MIT  */
 package com.barrybecker4.game.twoplayer.common.search.strategy;
 
+import java.io.*;
 import com.barrybecker4.common.format.FormatUtil;
 import com.barrybecker4.common.geometry.ByteLocation;
 import com.barrybecker4.game.common.MoveList;
 import com.barrybecker4.game.twoplayer.common.TwoPlayerMove;
 import com.barrybecker4.game.twoplayer.common.search.TwoPlayerMoveStub;
+import com.barrybecker4.game.twoplayer.common.search.tree.NodeAttributes;
+
 import junit.framework.TestCase;
 import org.junit.Test;
 
@@ -38,6 +41,10 @@ public class UctNodeTest {
     public void testConstructionOfNodeWithNoChildren() {
 
         uctNode = new UctNode<>(P2_MOVE);
+        NodeAttributes tempAttr = new NodeAttributes();
+        tempAttr.put("visits", "0");
+        tempAttr.put("wins", "0.0");
+        tempAttr.put("winRate", "0.50122");
 
         assertEquals("Unexpected move", P2_MOVE, uctNode.move);
         assertEquals("Unexpected bestNode", null, uctNode.findBestChildMove(WIN_RATE));
@@ -45,9 +52,12 @@ public class UctNodeTest {
         assertEquals("Unexpected numVisits", 0, uctNode.getNumVisits());
         // The winrate is 0.5 (tie) + 10/WINNING = 0.50122
         assertEquals("Unexpected winRate", 0.5012207f, uctNode.getWinRate(), TOL);
-        assertEquals("Unexpected attrs", "{wins=0.0, visits=0, winRate=0.50122}", uctNode.getAttributes().toString());
+        assertEquals("Unexpected attrs", tempAttr, uctNode.getAttributes());
         assertEquals("Unexpected uctValue",
                 1000.50122, uctNode.calculateUctValue(1.0, 1), TOL);
+        // System.out.println("\n\noutput result to check equal: \n");
+        // System.out.println("Unexpected move " + P2_MOVE + uctNode.move);
+        
     }
 
     @Test

--- a/test/com/barrybecker4/game/twoplayer/common/search/strategy/UctNodeTest.java
+++ b/test/com/barrybecker4/game/twoplayer/common/search/strategy/UctNodeTest.java
@@ -1,7 +1,6 @@
 /* Copyright by Barry G. Becker, 2000-2011. Licensed under MIT License: http://www.opensource.org/licenses/MIT  */
 package com.barrybecker4.game.twoplayer.common.search.strategy;
 
-import java.io.*;
 import com.barrybecker4.common.format.FormatUtil;
 import com.barrybecker4.common.geometry.ByteLocation;
 import com.barrybecker4.game.common.MoveList;
@@ -54,10 +53,7 @@ public class UctNodeTest {
         assertEquals("Unexpected winRate", 0.5012207f, uctNode.getWinRate(), TOL);
         assertEquals("Unexpected attrs", tempAttr, uctNode.getAttributes());
         assertEquals("Unexpected uctValue",
-                1000.50122, uctNode.calculateUctValue(1.0, 1), TOL);
-        // System.out.println("\n\noutput result to check equal: \n");
-        // System.out.println("Unexpected move " + P2_MOVE + uctNode.move);
-        
+                1000.50122, uctNode.calculateUctValue(1.0, 1), TOL);        
     }
 
     @Test

--- a/test/com/barrybecker4/game/twoplayer/mancala/move/MoveMakerTest.java
+++ b/test/com/barrybecker4/game/twoplayer/mancala/move/MoveMakerTest.java
@@ -93,10 +93,14 @@ public class MoveMakerTest {
         MancalaMove move = new MancalaMove(true, new ByteLocation(1, 4), (byte)2, 0);
         moveMaker.makeMove(move);
 
+        Captures tempCap = new Captures();
+        tempCap.put(new ByteLocation(1,2), (byte)1);
+        tempCap.put(new ByteLocation(2,2), (byte)3);
+
         // The captures describe where the captures stones came from
         assertEquals("Unexpected captures.",
-                "{(row=1, column=2)=1, (row=2, column=2)=3}",
-                move.getCaptures().toString());
+                tempCap,
+                move.getCaptures());
 
         // note that stones from 1, 2 and 2,2, are moved to p1's home
         verifier.checkOverallBoard(4, 0, 4, 0, 3, 3, 3, 0,
@@ -109,9 +113,14 @@ public class MoveMakerTest {
         MancalaMove move = new MancalaMove(false, new ByteLocation(2, 3), (byte)2, 0);
         moveMaker.makeMove(move);
 
+        Captures tempCap = new Captures();
+        tempCap.put(new ByteLocation(2,5), (byte)1);
+        tempCap.put(new ByteLocation(1,5), (byte)3);
+
+
         assertEquals("Unexpected captures.",
-                "{(row=1, column=5)=3, (row=2, column=5)=1}",
-                move.getCaptures().toString());
+                tempCap,
+                move.getCaptures());
 
         // note that stones from 1,2 and 2,2, are moved to p1's home
         verifier.checkOverallBoard(0, 3, 3, 3, 0, 3, 3, 4,
@@ -129,10 +138,18 @@ public class MoveMakerTest {
         MancalaMove move = new MancalaMove(true, new ByteLocation(1, 4), (byte)1, 0);
         moveMaker.makeMove(move);
 
+        Captures tempCap = new Captures();
+        tempCap.put(new ByteLocation(1,3), (byte)1);
+        tempCap.put(new ByteLocation(2,2), (byte)3);
+        tempCap.put(new ByteLocation(2,3), (byte)3);
+        tempCap.put(new ByteLocation(2,4), (byte)3);
+        tempCap.put(new ByteLocation(2,5), (byte)3);
+        tempCap.put(new ByteLocation(2,6), (byte)3);
+        tempCap.put(new ByteLocation(2,7), (byte)3);
+
         assertEquals("Unexpected captures.",
-                "{(row=1, column=3)=1, (row=2, column=2)=3, (row=2, column=3)=3, (row=2, column=4)=3, " +
-                        "(row=2, column=5)=3, (row=2, column=6)=3, (row=2, column=7)=3}",
-                move.getCaptures().toString());
+                tempCap,
+                move.getCaptures());
 
         verifier.checkOverallBoard(4, 0, 0, 0, 0, 0, 0, 15,
                 0, 0, 0, 0, 0, 0);
@@ -149,10 +166,18 @@ public class MoveMakerTest {
         MancalaMove move = new MancalaMove(false, new ByteLocation(2, 4), (byte)1, 0);
         moveMaker.makeMove(move);
 
+        Captures tempCap = new Captures();
+        tempCap.put(new ByteLocation(2,5), (byte)1);
+        tempCap.put(new ByteLocation(1,2), (byte)3);
+        tempCap.put(new ByteLocation(1,3), (byte)3);
+        tempCap.put(new ByteLocation(1,4), (byte)3);
+        tempCap.put(new ByteLocation(1,5), (byte)3);
+        tempCap.put(new ByteLocation(1,6), (byte)3);
+        tempCap.put(new ByteLocation(1,7), (byte)3);
+
         assertEquals("Unexpected captures.",
-                "{(row=1, column=2)=3, (row=1, column=3)=3, (row=1, column=4)=3, (row=1, column=5)=3, " +
-                        "(row=1, column=6)=3, (row=1, column=7)=3, (row=2, column=5)=1}",
-                move.getCaptures().toString());
+                tempCap,
+                move.getCaptures());
 
         verifier.checkOverallBoard(15, 0, 0, 0, 0, 0, 0, 4,
                 0, 0, 0, 0, 0, 0);
@@ -167,10 +192,17 @@ public class MoveMakerTest {
         MancalaMove move = new MancalaMove(true, new ByteLocation(1, 2), (byte)1, 0);
         moveMaker.makeMove(move);
 
+        Captures tempCap = new Captures();
+        tempCap.put(new ByteLocation(2,2), (byte)3);
+        tempCap.put(new ByteLocation(2,3), (byte)3);
+        tempCap.put(new ByteLocation(2,4), (byte)3);
+        tempCap.put(new ByteLocation(2,5), (byte)3);
+        tempCap.put(new ByteLocation(2,6), (byte)3);
+        tempCap.put(new ByteLocation(2,7), (byte)3);
+
         assertEquals("Unexpected captures.",
-                "{(row=2, column=2)=3, (row=2, column=3)=3, (row=2, column=4)=3, (row=2, column=5)=3, " +
-                        "(row=2, column=6)=3, (row=2, column=7)=3}",
-                move.getCaptures().toString());
+                tempCap,
+                move.getCaptures());
 
         verifier.checkOverallBoard(1, 0, 0, 0, 0, 0, 0, 18,
                 0, 0, 0, 0, 0, 0);
@@ -185,10 +217,17 @@ public class MoveMakerTest {
         MancalaMove move = new MancalaMove(false, new ByteLocation(2, 7), (byte)1, 0);
         moveMaker.makeMove(move);
 
+        Captures tempCap = new Captures();
+        tempCap.put(new ByteLocation(1,2), (byte)3);
+        tempCap.put(new ByteLocation(1,3), (byte)3);
+        tempCap.put(new ByteLocation(1,4), (byte)3);
+        tempCap.put(new ByteLocation(1,5), (byte)3);
+        tempCap.put(new ByteLocation(1,6), (byte)3);
+        tempCap.put(new ByteLocation(1,7), (byte)3);
+
         assertEquals("Unexpected captures.",
-                "{(row=1, column=2)=3, (row=1, column=3)=3, (row=1, column=4)=3, (row=1, column=5)=3, " +
-                        "(row=1, column=6)=3, (row=1, column=7)=3}",
-                move.getCaptures().toString());
+                tempCap,
+                move.getCaptures());
         verifier.checkOverallBoard(18, 0, 0, 0, 0, 0, 0, 1,
                 0, 0, 0, 0, 0, 0);
     }
@@ -286,11 +325,16 @@ public class MoveMakerTest {
         move5.setFollowUpMove(move6);
         moveMaker.makeMove(move1);
 
+        Captures tempCap = new Captures();
+        tempCap.put(new ByteLocation(1,3), (byte)1);
+        tempCap.put(new ByteLocation(2,3), (byte)3);
+
+
         assertEquals("Unexpected captures.", "{}",  move1.getCaptures().toString());
 
         assertEquals("Unexpected captures.",
-                "{(row=1, column=3)=1, (row=2, column=3)=3}",
-                move6.getCaptures().toString());
+               tempCap,
+                move6.getCaptures());
 
         verifier.checkOverallBoard(9, 4, 0, 0, 0, 5, 6, 0,
                                       3, 0, 3, 3, 3, 3);


### PR DESCRIPTION
## Description

Fixed the flaky test `testConstructionOfNodeWithNoChildren` inside the `UctNodeTest` class.
Fixed the flaky test `testCrazyP1Combo` `testFinalPlayer1MoveInHomeBin` `testFinalPlayer1MoveOnPlayersSide` `testFinalPlayer2MoveInHomeBin` `testFinalPlayer2MoveOnPlayersSide` `testPlayer1CapturingMove` `testPlayer2CapturingMove` inside the `MoveMakerTest` class.


### Root Cause
**UctNodeTest**
The test `testConstructionOfNodeWithNoChildren` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed because it tries to compare two strings, but the method `uctNode.getAttributes()` returns a NodeAttribute Object. 

https://github.com/Rette66/bb4-games/blob/5dfcc6be8d8294f253f94bf342fad4f9bdb557d7/test/com/barrybecker4/game/twoplayer/common/search/strategy/UctNodeTest.java#L48
https://github.com/Rette66/bb4-games/blob/5dfcc6be8d8294f253f94bf342fad4f9bdb557d7/source/com/barrybecker4/game/twoplayer/common/search/strategy/UctNode.java#L190-L196

However, the `NodeAttribute` class extends from Java Hashmap.

https://github.com/Rette66/bb4-games/blob/5dfcc6be8d8294f253f94bf342fad4f9bdb557d7/source/com/barrybecker4/game/twoplayer/common/search/tree/NodeAttributes.java#L21

Java Hashmap does not guarantee the order of elements in it. Therefore, it fails when applying `toString()` and is compared with a hardcoded string.

**MoveMakerTest**
All tests I mentioned at the beginning has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. These tests failed because they tried to compare two strings. They all have the same root cause, so I will use `testFinalPlayer1MoveInHomeBin` for instance.

https://github.com/Rette66/bb4-games/blob/5dfcc6be8d8294f253f94bf342fad4f9bdb557d7/test/com/barrybecker4/game/twoplayer/mancala/move/MoveMakerTest.java#L170-L173
https://github.com/Rette66/bb4-games/blob/5dfcc6be8d8294f253f94bf342fad4f9bdb557d7/source/com/barrybecker4/game/twoplayer/mancala/move/MancalaMove.java#L72-L74
https://github.com/Rette66/bb4-games/blob/5dfcc6be8d8294f253f94bf342fad4f9bdb557d7/source/com/barrybecker4/game/twoplayer/mancala/move/MancalaMove.java#L33

Method `move.getCaptures()` will return a Capture Object as inferred by the codes above. However, Capture Object is a Class that extends from Java HashMap.

https://github.com/Rette66/bb4-games/blob/5dfcc6be8d8294f253f94bf342fad4f9bdb557d7/source/com/barrybecker4/game/twoplayer/mancala/move/Captures.java#L11

Java Hashmap does not guarantee the order of elements in it. Therefore, the test fails when applying `toString()` to a Capture object and compares it with a hardcoded string.

### Fix
**UctNodeTest**
Test in this class is fixed by adding a temporary NodeAttribute `tempAttr` and putting information in the hard-coded string into this `tempAttr`.  Then compare `tempAttr`  with  `uctNode.getAttributes()`. Since these two are all NodeAttribute types, `assertEquals` can apply to them.

**MoveMakerTest**
Tests in this class are fixed by adding a temporary Capture `tempCap` and putting information in the hard-coded string into this `tempCap`.  Then compare `tempCap`  with  `move.getCaptures()`. Since these two are all Capture types, `assertEquals` can apply to them.

### How has this been tested?

1. Regular test - Successful
Command used -
```
./gradlew --info test --tests com.barrybecker4.game.twoplayer.common.search.strategy.UctNodeTest.testConstructionOfNodeWithNoChildren
```
for UctNodetTest class

Command used -
```
./gradlew --info test --tests com.barrybecker4.game.twoplayer.mancala.move.MoveMakerTest.Specific_Test_Name_Here
```
for MoveMakerTest class
Note: replace Specific_Test_Name_Here with the test names mentioned in the beginning.

2. NonDex test - Failed
Command used -
```
./gradlew --info nondexTest --tests=com.barrybecker4.game.twoplayer.common.search.strategy.UctNodeTest.testConstructionOfNodeWithNoChildren --nondexRuns=X
```
for UctNodetTest class

Command used -
```
./gradlew --info nondexTest --tests=com.barrybecker4.game.twoplayer.mancala.move.MoveMakerTest.Specific_Test_Name_Here --nondexRuns=X
```
for UctNodetTest class

Note: replace Specific_Test_Name_Here with the test names mentioned in the beginning.
Replace X with an int number.
The NonDex test passed after the fix.

